### PR TITLE
fix: bump starlette version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ PyYAML==6.0.3
 requests==2.32.5
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
-starlette==0.52.1
+starlette>=1.0.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3

--- a/src/app.py
+++ b/src/app.py
@@ -105,8 +105,8 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
     """
 
     async def dispatch(self, request: Request, call_next):
-        if settings.oidc_client_id and request.url.path not in _PUBLIC_PATHS and not is_authenticated(request):
-            if request.url.path.startswith("/api/"):
+        if settings.oidc_client_id and request.scope["path"] not in _PUBLIC_PATHS and not is_authenticated(request):
+            if request.scope["path"].startswith("/api/"):
                 return JSONResponse(
                     status_code=401,
                     content={"detail": "Authentication required"},


### PR DESCRIPTION
use scope["path"] instead of request.url.path in auth middleware (CVE-2026-48710)

request.url.path is derived from the Host header and can be forged to bypass the OIDCAuthMiddleware path checks entirely. scope["path"] comes from the ASGI request line and is not attacker-controlled. also bumps starlette to >=1.0.1.